### PR TITLE
feat: label-based dns credentials

### DIFF
--- a/backend/__tests__/acceptance/api.cloudProviderCredentials.spec.cjs
+++ b/backend/__tests__/acceptance/api.cloudProviderCredentials.spec.cjs
@@ -50,7 +50,6 @@ describe('api', function () {
       mockRequest.mockImplementationOnce(fixtures.secretbindings.mocks.list())
       mockRequest.mockImplementationOnce(fixtures.credentialsbindings.mocks.list())
       mockRequest.mockImplementationOnce(fixtures.secrets.mocks.list())
-      mockRequest.mockImplementationOnce(fixtures.secrets.mocks.list())
       mockRequest.mockImplementationOnce(fixtures.workloadidentities.mocks.list())
 
       const params = {
@@ -64,7 +63,7 @@ describe('api', function () {
         .expect('content-type', /json/)
         .expect(200)
 
-      expect(mockRequest).toHaveBeenCalledTimes(5)
+      expect(mockRequest).toHaveBeenCalledTimes(4)
       expect(mockRequest.mock.calls).toMatchSnapshot()
 
       expect(res.body).toMatchSnapshot()
@@ -73,7 +72,6 @@ describe('api', function () {
     it('should return no cloudProvider credentials', async function () {
       mockRequest.mockImplementationOnce(fixtures.secretbindings.mocks.list())
       mockRequest.mockImplementationOnce(fixtures.credentialsbindings.mocks.list())
-      mockRequest.mockImplementationOnce(fixtures.secrets.mocks.list())
       mockRequest.mockImplementationOnce(fixtures.secrets.mocks.list())
       mockRequest.mockImplementationOnce(fixtures.workloadidentities.mocks.list())
 
@@ -89,7 +87,7 @@ describe('api', function () {
         .expect('content-type', /json/)
         .expect(200)
 
-      expect(mockRequest).toHaveBeenCalledTimes(5)
+      expect(mockRequest).toHaveBeenCalledTimes(4)
       expect(mockRequest.mock.calls).toMatchSnapshot()
 
       expect(res.body).toMatchSnapshot()

--- a/frontend/__fixtures__/credentials.js
+++ b/frontend/__fixtures__/credentials.js
@@ -14,6 +14,7 @@ function createProviderCredentials (type, options = {}) {
     typeSecret = !typeWorkloadIdentity,
     createSecretBinding = typeSecret,
     createCredentialsBinding = true,
+    providerLabel = false,
   } = options
   const secretBindingName = `${name}-secretbinding`
   const credentialsBindingName = `${name}-credentialsbinding`
@@ -103,6 +104,9 @@ function createProviderCredentials (type, options = {}) {
         secret: 'cw==',
       },
     }
+    if (providerLabel) {
+      secret.metadata.labels = { [`provider.shoot.gardener.cloud/${type}`]: 'true' }
+    }
   }
 
   let workloadIdentity
@@ -119,6 +123,9 @@ function createProviderCredentials (type, options = {}) {
           type: 'foo-infra',
         },
       },
+    }
+    if (providerLabel) {
+      workloadIdentity.metadata.labels = { [`provider.shoot.gardener.cloud/${type}`]: 'true' }
     }
   }
 
@@ -150,8 +157,24 @@ const credentials = [
   createProviderCredentials('openstack'),
   createProviderCredentials('gcp'),
   createProviderCredentials('ironcore'),
-  createProviderCredentials('aws-route53'),
-  createProviderCredentials('azure-dns'),
+  createProviderCredentials('aws-route53', { createSecretBinding: false, createCredentialsBinding: false, providerLabel: true }),
+  createProviderCredentials('azure-dns', { createSecretBinding: false, createCredentialsBinding: false, providerLabel: true }),
+  {
+    secret: {
+      metadata: {
+        namespace: 'garden-test',
+        name: 'dual-dns-secret',
+        uid: 'secret-dual-dns-uid',
+        labels: {
+          'provider.shoot.gardener.cloud/aws-route53': 'true',
+          'provider.shoot.gardener.cloud/azure-dns': 'true',
+        },
+      },
+      data: {
+        secret: 'cw==',
+      },
+    },
+  },
 ]
 
 const secretBindings = credentials.map(item => item.secretBinding).filter(Boolean)

--- a/frontend/__tests__/composables/__snapshots__/useShootDns.spec.js.snap
+++ b/frontend/__tests__/composables/__snapshots__/useShootDns.spec.js.snap
@@ -111,7 +111,7 @@ exports[`composables > useShootDns > should delete extension dns providers > one
         "kind": "DNSConfig",
         "providers": [
           {
-            "secretName": undefined,
+            "secretName": "shoot-dns-service-dual-dns-secret",
             "type": "aws-route53",
           },
         ],
@@ -120,7 +120,16 @@ exports[`composables > useShootDns > should delete extension dns providers > one
       "type": "shoot-dns-service",
     },
   ],
-  "resources": [],
+  "resources": [
+    {
+      "name": "shoot-dns-service-dual-dns-secret",
+      "resourceRef": {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "name": "dual-dns-secret",
+      },
+    },
+  ],
 }
 `;
 
@@ -137,7 +146,7 @@ exports[`composables > useShootDns > should delete extension dns providers > two
             "type": "aws-route53",
           },
           {
-            "secretName": undefined,
+            "secretName": "shoot-dns-service-dual-dns-secret",
             "type": "aws-route53",
           },
         ],
@@ -153,6 +162,14 @@ exports[`composables > useShootDns > should delete extension dns providers > two
         "apiVersion": "v1",
         "kind": "Secret",
         "name": "aws-route53-secret",
+      },
+    },
+    {
+      "name": "shoot-dns-service-dual-dns-secret",
+      "resourceRef": {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "name": "dual-dns-secret",
       },
     },
   ],

--- a/frontend/__tests__/composables/useCloudProviderBinding.spec.js
+++ b/frontend/__tests__/composables/useCloudProviderBinding.spec.js
@@ -77,7 +77,7 @@ describe('useCloudProviderBinding composable', () => {
   function findBindingRef (name) {
     return ref(
       find(
-        [...global.fixtures.credentials.secretBindings, ...global.fixtures.credentials.credentialsBindings],
+        credentialStore.cloudProviderBindingList,
         b => b.metadata.name === name,
       ),
     )
@@ -151,9 +151,9 @@ describe('useCloudProviderBinding composable', () => {
     expect(bindingComposable.credentialUsageCount.value).toBe(1)
   })
 
-  it('counts shoots referencing dns credentialsbinding', () => {
-    const credentialsBindingRef = findBindingRef('aws-route53-credentialsbinding')
-    const bindingComposable = useCloudProviderBinding(credentialsBindingRef)
+  it('counts shoots referencing dns credential', () => {
+    const dnsSecretRef = findBindingRef('aws-route53-secret')
+    const bindingComposable = useCloudProviderBinding(dnsSecretRef)
     expect(bindingComposable.isDnsBinding.value).toBe(true)
     expect(bindingComposable.credentialUsageCount.value).toBe(2)
   })
@@ -178,5 +178,11 @@ describe('useCloudProviderBinding composable', () => {
     secretBindingRef.value.metadata.deletionTimestamp = new Date().toISOString()
     const bindingComposable = useCloudProviderBinding(secretBindingRef)
     expect(bindingComposable.isMarkedForDeletion.value).toBe(true)
+  })
+
+  it('creates virtual binding for each dns provider label', () => {
+    const bindings = credentialStore.cloudProviderBindingList.filter(b => b.metadata.name === 'dual-dns-secret')
+    expect(bindings).toHaveLength(2)
+    expect(bindings.map(b => b.provider.type).sort()).toEqual(['aws-route53', 'azure-dns'])
   })
 })

--- a/frontend/src/components/Credentials/GCredentialIcon.vue
+++ b/frontend/src/components/Credentials/GCredentialIcon.vue
@@ -28,6 +28,8 @@ import {
 import {
   isCredentialsBinding,
   isSecretBinding,
+  isSecret,
+  isWorkloadIdentity,
 } from '@/composables/credential/helper'
 
 const props = defineProps({
@@ -38,8 +40,11 @@ const props = defineProps({
 const binding = toRef(props, 'binding')
 
 const icon = computed(() => {
-  if (isSecretBinding(binding.value)) {
+  if (isSecret(binding.value) || isSecretBinding(binding.value)) {
     return 'mdi-key'
+  }
+  if (isWorkloadIdentity(binding.value)) {
+    return 'mdi-id-card'
   }
   if (isCredentialsBinding(binding.value)) {
     if (binding.value.credentialsRef.kind === 'Secret') {
@@ -53,6 +58,12 @@ const icon = computed(() => {
 })
 
 const tooltip = computed(() => {
+  if (isSecret(binding.value)) {
+    return 'Secret'
+  }
+  if (isWorkloadIdentity(binding.value)) {
+    return 'WorkloadIdentity'
+  }
   if (isSecretBinding(binding.value)) {
     return 'Secret (SecretBinding)'
   }

--- a/frontend/src/components/Credentials/GSelectCredential.vue
+++ b/frontend/src/components/Credentials/GSelectCredential.vue
@@ -186,7 +186,7 @@ export default {
     allowedBindings () {
       return this.cloudProviderBindingList
         ?.filter(binding => {
-          const name = binding.secretRef?.name || binding.cedentialsRef?.name
+          const name = binding.secretRef?.name || binding.credentialsRef?.name || binding.metadata?.name
           return !this.notAllowedSecretNames.includes(name)
         })
     },

--- a/frontend/src/composables/credential/helper.js
+++ b/frontend/src/composables/credential/helper.js
@@ -14,6 +14,12 @@ export function isSecretBinding (binding) {
 export function isCredentialsBinding (binding) {
   return binding?.kind === 'CredentialsBinding'
 }
+export function isSecret (binding) {
+  return binding?.kind === 'Secret'
+}
+export function isWorkloadIdentity (binding) {
+  return binding?.kind === 'WorkloadIdentity'
+}
 
 export function credentialRef (binding) {
   if (isSecretBinding(binding)) {
@@ -21,6 +27,13 @@ export function credentialRef (binding) {
   }
   if (isCredentialsBinding(binding)) {
     return binding?.credentialsRef
+  }
+  if (isSecret(binding) || isWorkloadIdentity(binding)) {
+    return {
+      namespace: binding?.metadata?.namespace,
+      name: binding?.metadata?.name,
+      kind: binding?.kind,
+    }
   }
   return undefined
 }
@@ -45,6 +58,12 @@ export function credentialKind (binding) {
   }
   if (isCredentialsBinding(binding)) {
     return binding?.credentialsRef?.kind
+  }
+  if (isSecret(binding)) {
+    return 'Secret'
+  }
+  if (isWorkloadIdentity(binding)) {
+    return 'WorkloadIdentity'
   }
   return undefined
 }


### PR DESCRIPTION
## Summary
- handle Secrets and WorkloadIdentities tagged with `provider.shoot.gardener.cloud/<type>` as DNS credentials
- stop generating CredentialsBindings for DNS Secrets and apply the provider label instead
- adjust backend credential APIs for label based DNS credentials and direct Secret/WorkloadIdentity deletion

## Testing
- `yarn workspace @gardener-dashboard/frontend test -u`
- `yarn workspace @gardener-dashboard/backend test` *(fails: Cannot find module '@gardener-dashboard/test-utils')*


------
https://chatgpt.com/codex/tasks/task_e_6890ad5dfb4883319725d6090753ba1d